### PR TITLE
Parallel reproduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ If you wish to run the program with a different python distribution, you can ins
 3. Double click on `sequential_sound_reproduction.bat`.
 4. Write `'y'` upon first prompt . (This step can be skipped on following reproductions, unless new devices are connected/disconnected).
 5. Read list of devices and select desired audio devices.
+
+**BETA**: you can play the audio in more than one device simultaneously by writing the desired device IDs between parentheses. **The reproductions are not perfectly synchronous.**
+
 6. Input ID numbers of desired audio output devices separated by spaces. You can input any order desired.
 7. Run `'test'` routine (write `'test'`, `'t'`, or simply hit the return key)
 
@@ -75,9 +78,11 @@ Its operation is described below.
 
 #### **First prompt:**  
 - By inputting 'y', 'Y', or 'yes', the list of devices connected to Portaudio is output.
-	- A second prompt asks the user for a list of desired output device IDs, separated by empty spaces. Any sequence of devices can be input.
+	- A second prompt asks the user for a list of desired output device IDs, separated by empty spaces. Any sequence of devices can be input, separated by spaces. 
+	
+	**BETA**: you can play the audio in more than one device simultaneously by writing the desired device IDs between parentheses. **The reproductions are not perfectly synchronous.**
 	- The user input is stored in the configuration file.
-	- **warning**: the device sampling rate and audio sampling rate must match.
+	
 - By hitting any other key, the connected device list is not shown and the ID assignment step is not performed
 	- The output device IDs are loaded directly from the configuration file.
 	
@@ -109,6 +114,8 @@ Configuration file. Stores relevant information for the correct operation of the
 - `[reproduction]`
 	- `audio_duration` -> audio duration in seconds. Default is the total duration of the selected audio file.  
 	- `wait_duration` -> wait time after each reproduction in second. Default 0.5s. It's recommended to include some wait_duration => 0.1s, in order to compensate for potential program latency.
+	- `audio_library` -> path to audio files to use in routines. default `audio/`
+	- `sampling_rate` -> desired reproduction sampling rate. default 192000 Hz. May be overwritten by selected audio file or devices sampling rates.
 
 ## Audio signal library
 ### audio\

--- a/dev/Nspeakers.py
+++ b/dev/Nspeakers.py
@@ -136,7 +136,9 @@ def play(IDlist: list, data: np.ndarray, dur=1, wait=0.5,global_sr=44100,t0=0):
     """
     Reproduce a single signal for a fixed duration and device.
 
-    """    
+    """
+    global current_frame
+    current_frame=0
     
     def callback(outdata, frames, time, status):
         global current_frame
@@ -148,8 +150,6 @@ def play(IDlist: list, data: np.ndarray, dur=1, wait=0.5,global_sr=44100,t0=0):
             outdata[chunksize:] = 0
             raise sd.CallbackStop()
         current_frame += chunksize
-    
-    
     
     
     jobs = []
@@ -173,7 +173,6 @@ def play(IDlist: list, data: np.ndarray, dur=1, wait=0.5,global_sr=44100,t0=0):
         
     for job in jobs:
         job.join()
-        
     
     return time.time()
     
@@ -188,7 +187,11 @@ def sequential_reproduction(buffer:np.ndarray, signal = 'test', duration = 1., w
     cprint("\nBegin \'" + signal + "\' signal output", 'light_blue')
     
     for i,ID in enumerate(device_IDs):
-        cprint("    - Device "+ str(i+1), "light_cyan")            
+        string = "    " + str(i+1)+". Device(s) [ "
+        for id in ID:
+            string += str(id) + " "
+        
+        cprint(string+"]", "light_cyan")            
         t0 = play(ID, buffer, duration, wait, global_sr=global_sr, t0=t0)
         
     return t0

--- a/dev/Nspeakers.py
+++ b/dev/Nspeakers.py
@@ -50,16 +50,23 @@ def inicio(ini_file='.\lib\config.ini', global_sr = 192000):
         if devdata['default_samplerate'] < global_sr:
             global_sr = devdata['default_samplerate']
 
-    repro = dict()
-    if read_config['reproduction']['audio_duration'] == '':
-        repro["dur"]=None
-    else:
-        repro["dur"]=float(read_config['reproduction']['audio_duration'])
+    repro = dict({"dur": None, "wait": 0.5, "lib": "audio/"})
+    
+    if 'reproduction' in read_config:
+        if ('audio_duration' in read_config['reproduction']):
+            if (read_config['reproduction']['audio_duration'] != ''):
+                repro["dur"]=float(read_config['reproduction']['audio_duration'])
         
-    if read_config['reproduction']['wait_duration'] == '':
-        repro["wait"]=.5
-    else:
-        repro["wait"]=float(read_config['reproduction']['wait_duration'])
+        if ('wait_duration' in read_config['reproduction']): 
+            if (read_config['reproduction']['wait_duration'] != ''):
+                repro["wait"]=float(read_config['reproduction']['wait_duration'])
+
+        if ('audio_library' in read_config['reproduction']): 
+            if (read_config['reproduction']['audio_library'] != ''):
+                repro["lib"]=read_config['reproduction']['audio_library']
+                
+                if not (repro["lib"].endswith("/") or repro["lib"].endswith('\\')):
+                    repro["lib"] += "\\"
 
     # 'reproduction mode' from call arguments
     mode = sys.argv[1] 
@@ -151,7 +158,7 @@ def audio_selection(audio_folder=".\\audio\\",audiopath=[]):
     cprint("\nSelect audio file by writing the corresponding index number from the list below.",attrs=["bold"])
     cprint("You may select multiple files to be played sequentially\n"+
             "by writing their indices in order separated by spaces.\n",'dark_grey')
-    cprint("current directory: \' "+audio_folder+"\\ \'",'yellow',attrs=["dark"])
+    cprint("current directory: \' "+audio_folder+" \'",'yellow',attrs=["dark"])
     print(" ")
     # loop over subfolders
     counter = 0
@@ -222,7 +229,7 @@ if __name__ == "__main__":
                 IsADirectoryError("./audio/test/ folder removed or missing.")
                 
         elif str.lower(mode) == 'custom' or str.lower(mode) == 'c' or mode == '':
-            audiopaths = audio_selection()
+            audiopaths = audio_selection(audio_folder=repro['lib'])
             for audio in audiopaths:
                 _,sr=sf.read(audio)
                 if sr<global_sr:

--- a/dev/Nspeakers.py
+++ b/dev/Nspeakers.py
@@ -132,7 +132,7 @@ def select_test_file(dir = 0, signal='test', folder = '.\\audio\\' ):
 
     return file
         
-def play(IDlist: list, data: np.ndarray, dur=1, wait=0.5,global_sr=44100,t0=0):
+def play(IDlist: list, data: np.ndarray, dur=1, wait=1,global_sr=44100,t0=0):
     """
     Reproduce a single signal for a fixed duration and device.
 
@@ -205,10 +205,30 @@ def run_test(test_dur = 30, device_IDs=[], global_sr=44100, t0=0):
     with a unique audio identifier.
     
     """
+    bufferlist = []
+    for i in range(len(device_IDs)):
+        audio = "audio/test/"+str(i+1)+".wav"
+        data,_ = sf.read(audio)
+        if len(data.shape)==1:
+            data = data.reshape(data.shape[0],1)
+        bufferlist.append(data)
+
+    cprint("\nBegin test signal output", 'light_blue')
+    
     timeout = time.time() + test_dur
 
-    while time.time() < timeout:
-        t0 = sequential_reproduction(device_IDs=device_IDs, global_sr=global_sr, t0=t0)
+    while time.time() < timeout:        
+        
+        for i,ID in enumerate(device_IDs):
+            string = "    " + str(i+1)+". Device(s) [ "
+            for id in ID:
+                string += str(id) + " "
+            
+            cprint(string+"]", "light_cyan")            
+            t0 = play(ID, data=bufferlist[i], global_sr=global_sr, t0=t0)
+        print()
+        
+    return t0
 
 
 def audio_selection(audio_folder=".\\audio\\",audiopath=[]):

--- a/dev/Nspeakers.py
+++ b/dev/Nspeakers.py
@@ -6,7 +6,7 @@ and a reproduction mode set as a string argument to the python program call.
 Author: João Fatela 
 Contact: joao.garrettfatela@unicampania.it
 Dipartimento di Architettura e Disegno Industriale, Università degli Studi della Campania 'Luigi Vanvitelli'
-22.11.2024
+24.11.2024
 """
 import os
 import configparser

--- a/dev/Nspeakers.py
+++ b/dev/Nspeakers.py
@@ -22,9 +22,9 @@ import threading
 current_frame=0
 
 def streamfunc(stream,duration):
-        stream.start()
-        time.sleep(duration)
-        stream.stop()
+    stream.start()
+    time.sleep(duration)
+    stream.stop()
 
 def organise_devices(s,l=[]):
     out = s.split("(",1)[0]
@@ -94,6 +94,10 @@ def inicio(ini_file='.\lib\config.ini', global_sr = 192000):
         if ('wait_duration' in read_config['reproduction']): 
             if (read_config['reproduction']['wait_duration'] != ''):
                 repro["wait"]=float(read_config['reproduction']['wait_duration'])
+                
+        if ('sampling_rate' in read_config['reproduction']): 
+            if (read_config['reproduction']['sampling_rate'] != ''):
+                global_sr=float(read_config['reproduction']['sampling_rate'])
 
         if ('audio_library' in read_config['reproduction']): 
             if (read_config['reproduction']['audio_library'] != ''):

--- a/dev/Nspeakers.py
+++ b/dev/Nspeakers.py
@@ -128,10 +128,12 @@ def play(ID: int, f, dur=1, wait=0.5,global_sr=44100,t0=0):
                                     callback=callback,
                                     device=ID,
                                     channels=wf.channels,
+                                    latency='low',
                                     blocksize=1024,
                                     finished_callback=event.set)
-        with stream:
-            event.wait()
+        stream.start()
+        time.sleep(dur)
+        stream.stop()
     
     return time.time()
     

--- a/dev/write_device_list.py
+++ b/dev/write_device_list.py
@@ -41,7 +41,8 @@ def main():
     
     #user prompt
     cprint("\n\n!READ THE LIST ABOVE CAREFULLY!",'yellow')
-    IDs = input("Enter desired audio device IDs separated by spaces: ") # ! not resilient to misspellings/wrong input
+    IDs = input("Enter desired audio device IDs separated by spaces.\n"+
+                "For simultaneous reproduction in more than one device, write desired devices between parentheses () : ") # ! not resilient to misspellings/wrong input
 
     # reading the config file data
     read_config = configparser.ConfigParser()

--- a/lib/config.ini
+++ b/lib/config.ini
@@ -1,10 +1,11 @@
 [paths]
-python_path = <your-python-path>
+python_path = <path_to_python.exe>
 
 [devices]
-device_id = <reproduction-device-id> # portaudio id of reproduction devices. Mind the sampling rate, since it must match the chosen signals!
+device_id = <audio_device_ids>
 
 [reproduction]
-audio_duration = # audio duration in seconds. Default 1s. Mind the duration of the input signals!
-wait_duration = # wait time after each reproduction in second. Default 0s. Note that the real wait time may be slightly longer, due to the processing time of the routine  
+audio_duration = # audio duration in seconds. Default is the duration of the selected audio. Mind the duration of the input signals!
+wait_duration  = # wait time after each reproduction in second. Default 0.5s. Note that the real wait time may be slightly longer, due to the processing time of the routine
+audio_library  = # path to audio library. default ./audio/
 

--- a/lib/config.ini
+++ b/lib/config.ini
@@ -1,11 +1,12 @@
 [paths]
-python_path = <path_to_python.exe>
+python_path = <python_path>
 
 [devices]
-device_id = <audio_device_ids>
+device_id = <device-list>
 
 [reproduction]
-audio_duration = # audio duration in seconds. Default is the duration of the selected audio. Mind the duration of the input signals!
-wait_duration  = # wait time after each reproduction in second. Default 0.5s. Note that the real wait time may be slightly longer, due to the processing time of the routine
-audio_library  = # path to audio library. default ./audio/
+audio_duration = 1    # audio duration in seconds. Default is the duration of the selected audio. Mind the duration of the input signals!
+wait_duration = 1     # wait time after each reproduction in second. Default 0.5s. Note that the real wait time may be slightly longer, due to the processing time of the routine
+audio_library =       # path to audio library. default ./audio/
+sampling_rate = 
 


### PR DESCRIPTION
## Changes
- support for devices playing audio at the same time
    - reproduction backend now on sounddevice.OutputStream()
    - multithreading to improve synchronicity
    - syntax: use parentheses to signal which devices should be played at same time.
        - e.g. play device 1, then 2, then 2 and 3 at the same time, then 2: `1 2 (2 3) 2` 
    - most of the processing done before play() function.
    - directly send audio buffers up and down the processing chain (faster than reading files)

## Issues
- closes #14 
- closes #3
- closes #2